### PR TITLE
Add caching for previously linted files

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "less": "~1.5.0",
     "underscore": "~1.5.2",
     "async": "~0.2.9",
-    "grunt-lib-contrib": "0.6.1"
+    "grunt-lib-contrib": "0.6.1",
+    "cache-swap": "0.0.5"
   },
   "peerDependencies": {
     "grunt": "~0.4.0"

--- a/spec/fixtures/valid.less
+++ b/spec/fixtures/valid.less
@@ -1,0 +1,11 @@
+.button {
+  background-color: #ddd;
+
+  &-text {
+    font-size: 12px;
+  }
+
+  &-icon {
+    color: blue;
+  }
+}

--- a/src/lint-cache.coffee
+++ b/src/lint-cache.coffee
@@ -1,0 +1,35 @@
+grunt = require 'grunt'
+CacheSwap = require 'cache-swap'
+path = require 'path'
+
+_ = grunt.util._
+
+# Grab the package info only once instead of on every instantiation
+packageInfo = grunt.file.readJSON(path.resolve(path.join(__dirname, '..', 'package.json')))
+
+class LintCache extends CacheSwap
+  @category = 'lesshashed'
+  
+  constructor: (opts) ->
+    # Ensure the opts are an object; can be passed as true
+    opts = {} unless _.isObject(opts)
+
+    super
+
+    # Key the directory off the version so upgrading causes fresh linting
+    @options.cacheDirName = "lesslint-#{packageInfo.version}"
+
+  clear: (done) ->
+    super LintCache.category, done
+
+  hasCached: (hash, done) ->
+    super LintCache.category, hash, done
+
+  getCached: (hash, done) ->
+    super LintCache.category, hash, done
+
+  addCached: (hash, done) ->
+    super LintCache.category, hash, '', done
+
+# Exporting an object so it isn't mistaken for a function
+module.exports = { LintCache }


### PR DESCRIPTION
Incorporated cache-swap as a file based persistent swap for previously
successfully linted less files.
- turned off by default
- adds a cache option with some opportunities to tweak where the files
  are cached
