### PR TITLE
Fix caching of imported files

### DIFF
--- a/spec/less-lint-task-spec.coffee
+++ b/spec/less-lint-task-spec.coffee
@@ -301,6 +301,5 @@ describe 'LESS Lint task', ->
         expect(LintCache.prototype.addCached.callCount).toBe(1)
 
         less = grunt.file.read(path.join(__dirname, 'fixtures', 'valid.less'))
-        expectedHash = crypto.createHash('md5').update(less).digest('base64')
-
-        expect(addCacheHash).toEqual expectedHash
+        expect(addCacheHash).toNotEqual null
+        expect(addCacheHash).toNotEqual ''


### PR DESCRIPTION
Closes #15
- Move hash key creating to after `parseLess` function
- De-indent and remove `processFile` since the caching call has been moved to `parseLess` function

This would be a stop gap until a more efficient solution can be found.
