### PR TITLE
Update jasmine-focused dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "grunt-coffeelint": "~0.0.8",
     "grunt-contrib-coffee": "~0.8.2",
     "grunt-shell": "~0.6.4",
-    "jasmine-focused": "~0.19.0",
+    "jasmine-focused": "~1.0.4",
     "rimraf": "~2.2.6",
     "tmp": "~0.0.23",
     "xml2js": "~0.4.1"


### PR DESCRIPTION
0.19.0 had an uncaught exception in the jasmine-node dependency.
