### PR TITLE
Remove dependency on grunt-lib-contrib

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,10 @@
     "async": "~0.2.10",
     "cache-swap": "~0.0.5",
     "csslint": "~0.10.0",
-    "grunt-lib-contrib": "~0.6.1",
     "less": "~1.6.1",
-    "underscore": "~1.6.0"
+    "underscore": "~1.6.0",
+    "strip-path": "~0.1.0",
+    "chalk": "~0.4.0"
   },
   "devDependencies": {
     "grunt": "~0.4.2",

--- a/src/less-lint-task.coffee
+++ b/src/less-lint-task.coffee
@@ -6,6 +6,9 @@
 async = require 'async'
 path = require 'path'
 crypto = require 'crypto'
+stripPath = require 'strip-path'
+_ = require 'underscore'
+chalk = require 'chalk'
 
 defaultLessOptions =
   cleancss: false
@@ -15,9 +18,6 @@ defaultLessOptions =
   syncImport: true
 
 module.exports = (grunt) ->
-  {stripPath} = require('grunt-lib-contrib').init grunt
-
-  _ = grunt.util._
 
   originalPositionFor = (css, less, file, line) ->
     cssLines = css.split('\n')
@@ -72,14 +72,14 @@ module.exports = (grunt) ->
 
     fileErrors = 0
 
-    grunt.log.writeln("#{file.yellow} (#{messages.length})")
+    grunt.log.writeln("#{chalk.yellow(file)} (#{messages.length})")
 
     messages = _.groupBy messages, ({message}) -> message
     for ruleMessage, ruleMessages of messages
       rule = ruleMessages[0].rule
       fullRuleMessage = "#{ruleMessage} "
       fullRuleMessage += "#{rule.desc} " if rule.desc and rule.desc isnt ruleMessage
-      grunt.log.writeln(fullRuleMessage + "(#{rule.id})".grey)
+      grunt.log.writeln(fullRuleMessage + chalk.grey("(#{rule.id})"))
 
       for message in ruleMessages
         line = message.line
@@ -91,16 +91,16 @@ module.exports = (grunt) ->
 
         if lineNumber >= 0
           message.line = lineNumber
-          errorPrefix = "#{stripPath(filePath, process.cwd())} #{lineNumber + 1}:".yellow
+          errorPrefix = chalk.yellow("#{stripPath(filePath, process.cwd())} #{lineNumber + 1}:")
 
           grunt.log.error("#{errorPrefix} #{less.split('\n')[lineNumber].trim()}")
         else
           cssLine = css.split('\n')[line]
           if cssLine?
-            errorPrefix = "#{line + 1}:".yellow
+            errorPrefix = chalk.yellow("#{line + 1}:")
             grunt.log.error("#{errorPrefix} #{cssLine.trim()}")
 
-          grunt.log.writeln("Failed to find map CSS line #{line + 1} to a LESS line.".yellow)
+          grunt.log.writeln(chalk.yellow("Failed to find map CSS line #{line + 1} to a LESS line."))
 
     fileErrors
 

--- a/src/lib/less-file.coffee
+++ b/src/lib/less-file.coffee
@@ -3,6 +3,7 @@ crypto = require 'crypto'
 LessParser = require './less-parser'
 CssLinter = require './css-linter'
 {LintCache} = require './lint-cache'
+chalk = require 'chalk'
 
 # Base Class representing a file to be linted
 class LessFile
@@ -11,11 +12,11 @@ class LessFile
   lint: (callback) ->
     # Parse the LESS into CSS
     @getCss (err, css) =>
-      return callback(new Error("Error parsing #{@filePath.yellow}: #{err.message}")) if err
+      return callback(new Error("Error parsing #{chalk.yellow(@filePath)}: #{err.message}")) if err
 
       # Lint the css
       @lintCss css, (err, result) =>
-        return callback(new Error("Error linting #{@filePath.yellow}: #{err.message}")) if err
+        return callback(new Error("Error linting #{chalk.yellow(@filePath)}: #{err.message}")) if err
 
         callback null, result, @getContents(), css
 


### PR DESCRIPTION
Closes #23 and #24
- Replace stripPath reference with strip-path module
- Replace .color use with chalk.color
- Adds dependencies on strip-path and chalk
- Removes dependency on grunt-lib-contrib
