### PR TITLE
Add default path to parse options

### DIFF
--- a/src/lib/less-parser.coffee
+++ b/src/lib/less-parser.coffee
@@ -1,4 +1,6 @@
 
+path = require 'path'
+
 _ = require 'underscore'
 {Parser} = require 'less'
 
@@ -16,7 +18,11 @@ module.exports = class LessParser
     opts = _.defaults(opts || {}, defaultLessOptions)
 
     # Set the options and create the parser
-    @opts = _.extend({ filename: fileName, sourceMaps: true }, opts)
+    @opts = _.extend({
+      filename: path.resolve(fileName),
+      paths: [path.dirname(path.resolve(fileName))]
+      sourceMaps: true
+    }, opts)
     @parser = new Parser(@opts)
 
   parse: (less, callback) ->

--- a/src/lib/lint-error-output.coffee
+++ b/src/lib/lint-error-output.coffee
@@ -1,4 +1,6 @@
 
+path = require 'path'
+
 {SourceMapConsumer} = require 'source-map'
 _ = require 'underscore'
 chalk = require 'chalk'
@@ -16,7 +18,7 @@ class LintErrorOutput
     # Shorthand references to result values
     messages = @result.lint.messages
     less = @result.less
-    file = @result.file
+    file = path.resolve(@result.file)
 
     fileContents = {}
     fileLines = {}
@@ -30,7 +32,7 @@ class LintErrorOutput
 
       isThisFile = source == file
 
-      return isThisFile or @grunt.file.isMatch importsToLint, source
+      return isThisFile or @grunt.file.isMatch(importsToLint, stripPath(source, process.cwd()))
 
     # Bug out if only import errors we don't care about
     return 0 if messages.length < 1


### PR DESCRIPTION
Closes #30
- Use fully resolved path for file names
- Pass paths option to LESS Parser
