### PR TITLE
Prevent hanging when file path is wrong

### DIFF
--- a/src/less-lint-task.coffee
+++ b/src/less-lint-task.coffee
@@ -43,6 +43,9 @@ module.exports = (grunt) ->
       formatterOutput += formatter.endFormat()
       grunt.file.write(dest, formatterOutput)
 
+  if 0 === this.filesSrc.length
+    return grunt.log.error("No files to process")
+
   grunt.registerMultiTask 'lesslint', 'Validate LESS files with CSS Lint', ->
     options = @options
       # Default to the less task options


### PR DESCRIPTION
Stumbled upon that one for a while as I had a wrong file path and was only pre-processing a single file: The task hangs and doesn't skip in case there is no file to Lint. Patch aborts if there are no files to process and returns an error.
