### PR TITLE
Fix delimiter issue in lint error output

### DIFF
--- a/src/lib/lint-error-output.coffee
+++ b/src/lib/lint-error-output.coffee
@@ -32,6 +32,10 @@ class LintErrorOutput
         line: message.line,
         column: message.col
 
+      # Fix path delimiter issues
+      if source
+        source = path.resolve source
+
       isThisFile = source == file
 
       return isThisFile or @grunt.file.isMatch(importsToLint, stripPath(source, process.cwd()))


### PR DESCRIPTION
Closes #43
- Add a `source = path.resolve` to normalize paths on windows
