### PR TITLE
make sure the messages are filtered out for formatters

### DIFF
--- a/src/lib/lint-error-output.coffee
+++ b/src/lib/lint-error-output.coffee
@@ -48,6 +48,9 @@ class LintErrorOutput
     # Bug out if only import errors we don't care about
     return 0 if messages.length < 1
 
+    # make sure the messages are filtered out for formatters
+    @result.lint.messages = messages
+
     # Group the errors by message
     messageGroups = _.groupBy messages, ({message, rule}) ->
       fullMsg = "#{message}"


### PR DESCRIPTION
What I want to achieve is to make sure the lint error messages in imported files are filtered using the same mechanism in the formatters as on the command line. At the moment there is no filtering that would take into consideration which imported files to include for external formatters ...
