### PR TITLE
fixed `paths` attribute passed to the less parser

### DIFF
--- a/spec/fixtures/included-path.less
+++ b/spec/fixtures/included-path.less
@@ -1,0 +1,1 @@
+@import "included.less";

--- a/spec/included-path/included.less
+++ b/spec/included-path/included.less
@@ -1,0 +1,1 @@
+//Just a comment

--- a/spec/less-lint-task-spec.coffee
+++ b/spec/less-lint-task-spec.coffee
@@ -228,6 +228,32 @@ describe 'LESS Lint task', ->
         expect(taskOutput).toContain '.notAFunction is undefined'
         expect(taskOutput).toContain '1 lint error in 1 file'
 
+  describe 'when the file has less options', ->
+    describe 'when the less options contains paths', ->
+      it 'will respect the passed paths', ->
+        grunt.config.init
+          pkg: grunt.file.readJSON(path.join(__dirname, 'fixtures', 'package.json'))
+
+          lesslint:
+            src: ['**/fixtures/included-path.less']
+            options:
+              less:
+                paths: ['spec/included-path']
+
+        grunt.loadTasks(path.resolve(__dirname, '..', 'tasks'))
+        tasksDone = false
+        grunt.registerTask 'done', 'done',  -> tasksDone = true
+        output = []
+
+        spyOn(process.stdout, 'write').andCallFake (data='') ->
+          output.push(data.toString())
+
+        grunt.task.run(['lesslint', 'done']).start()
+        waitsFor -> tasksDone
+        runs ->
+          taskOutput = output.join('')
+          expect(taskOutput).toContain '1 file lint free.'
+
   describe 'when csslint option csslintrc is set', ->
     it 'reads css options from csslintrc file', ->
       grunt.config.init

--- a/src/lib/less-parser.coffee
+++ b/src/lib/less-parser.coffee
@@ -16,11 +16,15 @@ module.exports = class LessParser
   constructor: (fileName, opts) ->
     # Make sure we have some default options if none passed
     opts = _.defaults(opts || {}, defaultLessOptions)
+    paths = [path.dirname(path.resolve(fileName))]
+
+    if opts.less and opts.less.paths
+      paths = paths.concat(opts.less.paths)
 
     # Set the options and create the parser
     @opts = _.extend({
       filename: path.resolve(fileName),
-      paths: [path.dirname(path.resolve(fileName))]
+      paths: paths,
       sourceMaps: true
     }, opts)
     @parser = new Parser(@opts)


### PR DESCRIPTION
**Note:** I have feeling that more is broken than just `less.paths` as there is no explicit passing of the `less` config options to the `Parser`.