### PR TITLE
Fixes #53 - make errors in imported files show in console for windows

### DIFF
--- a/src/lib/lint-error-output.coffee
+++ b/src/lib/lint-error-output.coffee
@@ -43,7 +43,14 @@ class LintErrorOutput
 
       isThisFile = source == file
 
-      return isThisFile or @grunt.file.isMatch(importsToLint, stripPath(source, process.cwd()))
+      # Store stripped file path
+      sourceStripped = stripPath(source, process.cwd())
+
+      # Prepare two versions of file path for matching,
+      # one with preceding slash and one without
+      sourceArray = [sourceStripped, sourceStripped + '\\']
+
+      return isThisFile or @grunt.file.isMatch(importsToLint, sourceArray)
 
     # Bug out if only import errors we don't care about
     return 0 if messages.length < 1


### PR DESCRIPTION
Secondary version adds preceding slash for import matching on windows, otherwise windows users have to remember to use a preceding slash for import globbing patterns.
