### PR TITLE
Update less-lint-task.coffee

### DIFF
--- a/src/less-lint-task.coffee
+++ b/src/less-lint-task.coffee
@@ -104,6 +104,8 @@ module.exports = (grunt) ->
         grunt.log.error("#{errorCount} lint #{grunt.util.pluralize(errorCount, 'error/errors')} in #{fileCount} #{grunt.util.pluralize(fileCount, 'file/files')}.")
         done(!options.failOnError)
 
+    done() if (!@filesSrc? || @filesSrc.length == 0)
+
   grunt.registerTask 'lesslint:clearCache', ->
     done = @async()
 


### PR DESCRIPTION
if no files are specified, this task stop the whole grunt chains of tasks without warning nor error.