### PR TITLE
Expose CSSLint for custom rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ lesslint:
 
 ### Using custom rules
 
-It is possible to create and use your own custom rules. To create rules, please refer to the [official CSSLint guidelines](https://github.com/CSSLint/csslint/wiki/Working-with-Rules). The only addition is that each custom rule file must import `CSSLint` using `{CSSLint} = require 'csslint'` for CoffeeScript or `var CSSLint = require('csslint').CSSLint;` for JavaScript.
+It is possible to create and use your own custom rules. To create rules, please refer to the [official CSSLint guidelines](https://github.com/CSSLint/csslint/wiki/Working-with-Rules). The only addition is that each custom rule file must import `CSSLint` using `CSSLint = require('grunt-lesslint').CSSLint`.
 
 You can enable your custom rules by adding a `customRules` configuration option:
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "grunt-lesslint",
   "version": "1.2.0",
   "description": "Grunt task for validating LESS files with CSS Lint",
-  "main": "./tasks/linter.js",
+  "main": "tasks/less-lint-task",
   "keywords": [
     "css",
     "grunt",

--- a/spec/fixtures/custom-rule.coffee
+++ b/spec/fixtures/custom-rule.coffee
@@ -1,4 +1,4 @@
-{CSSLint} = require 'csslint'
+CSSLint = require(process.cwd()).CSSLint
 
 CSSLint.addRule
 

--- a/src/less-lint-task.coffee
+++ b/src/less-lint-task.coffee
@@ -117,3 +117,5 @@ module.exports = (grunt) ->
       grunt.log.error(err.message) if err
 
       done()
+
+module.exports.CSSLint = CSSLint


### PR DESCRIPTION
This allows custom rules to import the version of CSSLint that grunt-lesslint uses, instead of requiring their package to install its own version of CSSLint, which might be different and potentially cause problems.

A custom rule file would start with `CSSLint = require('grunt-lesslint').CSSLint` instead of the previous `{CSSLint} = require 'csslint'`.