### PR TITLE
Use container based Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,5 @@ notifications:
 
 node_js:
   - 0.10
+
+sudo: false


### PR DESCRIPTION
This should make the [Travis builds start faster](http://docs.travis-ci.com/user/migrating-from-legacy/).