### PR TITLE
Update less to 2.5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-lesslint",
-  "version": "1.4.1",
+  "version": "2.0.0",
   "description": "Grunt task for validating LESS files with CSS Lint",
   "main": "tasks/less-lint-task",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "cache-swap": "~0.1.0",
     "chalk": "~0.5.1",
     "csslint": "~0.10.0",
-    "less": "~1.7.5",
+    "less": "~2.5.3",
     "lodash": "~2.4.1",
     "source-map": "~0.1.33",
     "strip-json-comments": "^1.0.4",

--- a/src/lib/less-file.coffee
+++ b/src/lib/less-file.coffee
@@ -50,20 +50,6 @@ class LessFile
     @digest
 
   getCss: (callback) ->
-    @getTree (err, tree) ->
-      return callback(err) if err
-
-      css = sourceMap = ''
-      if tree
-        css = tree.toCSS({
-          sourceMap: true
-          writeSourceMap: (output) -> sourceMap = output
-        })
-
-      callback null, css, sourceMap
-
-  # Just in case someone needs just the tree for something later
-  getTree: (callback) ->
     contents = @getContents()
 
     # Bug out early if no LESS content
@@ -71,7 +57,8 @@ class LessFile
 
     parser = new LessParser(@filePath, @options)
 
-    parser.parse contents, callback
+    parser.render contents, callback
+
 
 # An in-memory hold of import contents and hashes
 sharedImportsContents = {}

--- a/src/lib/less-parser.coffee
+++ b/src/lib/less-parser.coffee
@@ -2,7 +2,7 @@
 path = require 'path'
 
 _ = require 'lodash'
-{Parser} = require 'less'
+less = require 'less'
 
 defaultLessOptions =
   cleancss: false
@@ -25,12 +25,12 @@ module.exports = class LessParser
     @opts = _.extend({
       filename: path.resolve(fileName),
       paths: paths,
-      sourceMaps: true
+      sourceMap: {}
     }, opts)
-    @parser = new Parser(@opts)
 
-  parse: (less, callback) ->
+  render: (contents, callback) ->
     try
-      @parser.parse less, callback
+      less.render contents, @opts, (err, output) ->
+        callback err, output?.css, output?.map
     catch err
       callback err


### PR DESCRIPTION
Fixes #79.

I dropped the `getTree()` method on `LessFile`, since it's not used and I couldn't easily get the two-step parsing to work with the new API.