### PR TITLE
Update minimum peerDependency version of Grunt to 0.4.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,6 @@
     "xml2js": "~0.4.1"
   },
   "peerDependencies": {
-    "grunt": ">=0.4.0"
+    "grunt": ">=0.4.5"
   }
 }


### PR DESCRIPTION
This will maintain the previous minimum version.