### PR TITLE
Let the LessParser use 'options.less' instead 'options'.

### DIFF
--- a/src/lib/less-parser.coffee
+++ b/src/lib/less-parser.coffee
@@ -19,7 +19,7 @@ module.exports = class LessParser
     paths = [path.dirname(path.resolve(fileName))]
 
     if opts and opts.paths
-      paths = paths.concat(opts.less.paths)
+      paths = paths.concat(opts.paths)
 
     # Set the options and create the parser
     @opts = _.extend({

--- a/src/lib/less-parser.coffee
+++ b/src/lib/less-parser.coffee
@@ -15,10 +15,10 @@ defaultLessOptions =
 module.exports = class LessParser
   constructor: (fileName, opts) ->
     # Make sure we have some default options if none passed
-    opts = _.defaults(opts || {}, defaultLessOptions)
+    opts = _.defaults(opts.less || {}, defaultLessOptions)
     paths = [path.dirname(path.resolve(fileName))]
 
-    if opts.less and opts.less.paths
+    if opts and opts.paths
       paths = paths.concat(opts.less.paths)
 
     # Set the options and create the parser


### PR DESCRIPTION
This correction makes less options in the task settings are not ignored.