### PR TITLE
Issue #90: Add support for showing lint warnings without failing the grunt task.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,72 @@ lesslint:
       csslintrc: '.csslintrc'
 ```
 
+### Allow lint warnings without failing the grunt task
+
+The `failOnWarning` configuration option is now available to allow any failing
+lint rules set to "warn" to not fail the grunt task.
+
+To maintain backwards-compatibility: 
+- This option's value is defaulted to `failOnWarning: true`, which will continue 
+   to fail the grunt task on *any* failed rule. When using the default option, the 
+   following example output shows the task failure due to failed lint rules 
+   configured as "warnings":
+
+```
+      >> 58 lint issues in 167 files (0 errors, 58 warnings)
+      Warning: Task "lesslint" failed. Use --force to continue.
+```
+
+- Setting `failOnError: false` will act as a **complete** override for both 
+   settings: don't fail grunt task if EITHER lint rule __warning(s)__ or __error(s)__ 
+   are found. Example Config:
+
+```coffeescript
+      lesslint:
+        src: ['less/*.less']
+        options:
+          csslint:
+            'known-properties': true
+            csslintrc: '.csslintrc'
+          failOnError: false
+```
+
+By setting `failOnWarning: false`, any failing rule configured
+to "warn" will no longer fail the grunt task:
+
+```coffeescript
+lesslint:
+  src: ['less/*.less']
+  options:
+    csslint:
+      'known-properties': true
+      csslintrc: '.csslintrc'
+    failOnWarning: false
+```
+
+This example's task output shows the task completing without
+failure, even when there are failed lint rules configured as "warnings":
+
+```
+>> 58 lint issues in 167 files (0 errors, 58 warnings)
+Done, without errors.
+```
+
+__Notes:__
+
+The new task summary output is borrowed from equivalent output used by eslint:
+```
+✖ 31 problems (0 errors, 31 warnings)
+```
+
+This option is meant to afford large projects the recourse of a staged adoption
+strategy of specific CSS rules. New rules may be activated to trigger a warning
+notification across teams without breaking the build and deployment. Once
+existing infractions are addressed, those rules would then be configured from
+"warning" setting to "error", to finalize their enforcement (by blocking any
+subsequent build attempts).
+
+
 ### LESS
 
 You can configure the LESS parser, such as for adding include paths,
@@ -121,4 +187,3 @@ Values of 0 shouldn't have units specified. You don't need to specify units when
 
 - In v3.0.0 `options` is no longer passed to the LESS compiler. `options.less` is passed instead, as described by the documentation.
 - In v2.0.0 the LESS compiler was updated to v2.5.3
-

--- a/spec/less-lint-task-spec.coffee
+++ b/spec/less-lint-task-spec.coffee
@@ -37,8 +37,7 @@ describe 'LESS Lint task', ->
       expect(taskOutput).toContain 'padding: 0px;'
       expect(taskOutput).toContain 'margin: 0em;'
       expect(taskOutput).toContain 'border-width: 0pt;'
-      expect(taskOutput).toContain '4 lint errors in 1 file.'
-
+      expect(taskOutput).toContain '4 lint issues in 1 file (0 errors, 4 warnings)'
       # A little bit of a hack until csslint reports first id column instead of 0
       hasIdorBodyError = taskOutput.indexOf('#id {') > -1 || taskOutput.indexOf('body {') > -1
       expect(hasIdorBodyError).toBe true
@@ -70,6 +69,61 @@ describe 'LESS Lint task', ->
     waitsFor -> tasksDone
     runs ->
       expect(errorCount).toBe 0
+
+  it 'issues return code 0, if failOnWarning is set to false, with failed rule warnings', ->
+    grunt.config.init
+      pkg: grunt.file.readJSON(path.join(__dirname, 'fixtures', 'package.json'))
+
+      lesslint:
+        src: ['**/fixtures/imports.less']
+        options:
+          imports: ['**/fixtures/file.less']
+          failOnWarning: false
+
+    grunt.loadTasks(path.resolve(__dirname, '..', 'tasks'))
+    tasksDone = false
+    grunt.registerTask 'done', 'done',  -> tasksDone = true
+    output = []
+    spyOn(process.stdout, 'write').andCallFake (data='') ->
+      output.push(data.toString())
+
+    errorCount = 0
+    grunt.task.options({
+      error: ->
+        errorCount++
+    })
+    grunt.task.run(['lesslint', 'done']).start()
+
+    waitsFor -> tasksDone
+    runs ->
+      expect(errorCount).toBe 0
+
+  it 'issues return code 1, if failOnWarning is set to false, with failed rule errors', ->
+    grunt.config.init
+      pkg: grunt.file.readJSON(path.join(__dirname, 'fixtures', 'package.json'))
+
+      lesslint:
+        src: ['**/fixtures/invalid.less']
+        options:
+          failOnWarning: false
+
+    grunt.loadTasks(path.resolve(__dirname, '..', 'tasks'))
+    tasksDone = false
+    grunt.registerTask 'done', 'done',  -> tasksDone = true
+    output = []
+    spyOn(process.stdout, 'write').andCallFake (data='') ->
+      output.push(data.toString())
+
+    errorCount = 0
+    grunt.task.options({
+      error: ->
+        errorCount++
+    })
+    grunt.task.run(['lesslint', 'done']).start()
+
+    waitsFor -> tasksDone
+    runs ->
+      expect(errorCount).toBe 1
 
   describe 'when the less file is empty', ->
     it 'does not log an error', ->
@@ -120,7 +174,7 @@ describe 'LESS Lint task', ->
           expect(taskOutput).toContain 'padding: 0px;'
           expect(taskOutput).toContain 'margin: 0em;'
           expect(taskOutput).toContain 'border-width: 0pt;'
-          expect(taskOutput).toContain '4 lint errors in 1 file.'
+          expect(taskOutput).toContain '4 lint issues in 1 file (0 errors, 4 warnings)'
           expect(taskOutput).not.toContain 'Failed to find map CSS'
 
           # A little bit of a hack until csslint reports first id column instead of 0
@@ -151,7 +205,7 @@ describe 'LESS Lint task', ->
           expect(taskOutput).toContain 'padding: 0px;'
           expect(taskOutput).toContain 'margin: 0em;'
           expect(taskOutput).toContain 'border-width: 0pt;'
-          expect(taskOutput).toContain '4 lint errors in 1 file.'
+          expect(taskOutput).toContain '4 lint issues in 1 file (0 errors, 4 warnings)'
           expect(taskOutput).not.toContain 'Failed to find map CSS'
 
           # A little bit of a hack until csslint reports first id column instead of 0
@@ -241,7 +295,7 @@ describe 'LESS Lint task', ->
       runs ->
         taskOutput = output.join('')
         expect(taskOutput).toContain "'does-not-exist.less' wasn't found"
-        expect(taskOutput).toContain '1 lint error in 1 file'
+        expect(taskOutput).toContain '1 lint issue in 1 file (1 error, 0 warnings)'
 
     it 'reports the compile errors for missing functions', ->
       grunt.config.init
@@ -261,7 +315,7 @@ describe 'LESS Lint task', ->
       runs ->
         taskOutput = output.join('')
         expect(taskOutput).toContain '.notAFunction is undefined'
-        expect(taskOutput).toContain '1 lint error in 1 file'
+        expect(taskOutput).toContain '1 lint issue in 1 file (1 error, 0 warnings)'
 
   describe 'when the file has less options', ->
     describe 'when the less options contains paths', ->
@@ -311,7 +365,7 @@ describe 'LESS Lint task', ->
       runs ->
         taskOutput = output.join('')
         expect(taskOutput).toContain 'margin: 0 !important'
-        expect(taskOutput).toContain '1 lint error in 1 file'
+        expect(taskOutput).toContain '1 lint issue in 1 file (0 errors, 1 warning)'
 
     it 'reads css options from csslintrc file and picks up other rules as well', ->
       grunt.config.init
@@ -358,7 +412,7 @@ describe 'LESS Lint task', ->
         runs ->
           taskOutput = output.join('')
           expect(taskOutput).toContain 'margin: 0 !important'
-          expect(taskOutput).toContain '1 lint error in 1 file'
+          expect(taskOutput).toContain '1 lint issue in 1 file (0 errors, 1 warning)'
 
   describe 'when cache option is set', ->
     it 'caches previously linted files for faster performance', ->
@@ -443,7 +497,7 @@ describe 'LESS Lint task', ->
         taskOutput = output.join('')
         expect(taskOutput).toContain 'BACKGROUND-COLOR: #FFF;'
         expect(taskOutput).toContain 'Uppercase letters looks bad. Properties should be in lowercase. (lowercase-properties)'
-        expect(taskOutput).toContain '1 lint error in 1 file.'
+        expect(taskOutput).toContain '1 lint issue in 1 file (0 errors, 1 warning)'
         expect(errorCount).toBe 1
 
     it 'does not disable the default CSSLint rule set', ->
@@ -475,7 +529,7 @@ describe 'LESS Lint task', ->
         expect(taskOutput).toContain 'padding: 0px;'
         expect(taskOutput).toContain 'margin: 0em;'
         expect(taskOutput).toContain 'border-width: 0pt;'
-        expect(taskOutput).toContain '4 lint errors in 1 file.'
+        expect(taskOutput).toContain '4 lint issues in 1 file (0 errors, 4 warnings)'
 
         # A little bit of a hack until csslint reports first id column instead of 0
         hasIdorBodyError = taskOutput.indexOf('#id {') > -1 || taskOutput.indexOf('body {') > -1
@@ -511,8 +565,7 @@ describe 'LESS Lint task', ->
       waitsFor -> tasksDone
       runs ->
         taskOutput = output.join('')
-        expect(taskOutput).toContain '1 lint error in 1 file.'
-        expect(taskOutput).toContain '4 lint errors in 2 files.'
+        expect(taskOutput).toContain '4 lint issues in 2 files (0 errors, 4 warnings)'
         expect(errorCount).toBe 2
 
     it 'allows the same custom rule configurations to be used on other targets executed later', ->
@@ -546,6 +599,5 @@ describe 'LESS Lint task', ->
       waitsFor -> tasksDone
       runs ->
         taskOutput = output.join('')
-        expect(taskOutput).toContain '1 lint error in 1 file.'
-        expect(taskOutput).toContain '1 lint error in 2 files.'
+        expect(taskOutput).toContain '1 lint issue in 2 files (0 errors, 1 warning)'
         expect(errorCount).toBe 2

--- a/src/lib/lint-error-output.coffee
+++ b/src/lib/lint-error-output.coffee
@@ -62,8 +62,9 @@ class LintErrorOutput
     @result.lint.messages = messages
 
     # Group the errors by message
-    messageGroups = _.groupBy messages, ({message, rule}) ->
+    messageGroups = _.groupBy messages, ({message, rule, type}) ->
       fullMsg = "#{message}"
+      fullMsg = "(#{type}) #{fullMsg}" if type? and type.length isnt 0
       fullMsg += " #{rule.desc}" if rule.desc and rule.desc isnt message
       fullMsg
 


### PR DESCRIPTION
  - src changes
  - fix broken tests due to new code.
  - add test cases to verify grunt task pass/fail based on various option settings