### PR TITLE
Use color coding to tell if a lint violation caused a build failure

### DIFF
--- a/spec/lint-error-output-spec.coffee
+++ b/spec/lint-error-output-spec.coffee
@@ -13,7 +13,7 @@ describe 'lint-error-output', ->
     it 'can process errors with no lines', (done) ->
       testResult = _.clone(exampleErrorResult)
       testResult.sourceMap = JSON.parse(testResult.sourceMap)
-      output = new LintErrorOutput(testResult, grunt)
+      output = new LintErrorOutput(testResult, {failOnError: true, failOnWarning: true}, grunt)
 
       results = ''
       addResults = (msg) -> results += msg + '\n'

--- a/src/less-lint-task.coffee
+++ b/src/less-lint-task.coffee
@@ -88,7 +88,7 @@ module.exports = (grunt) ->
           # Save for later use in formatters
           results[file] = lintResult
           # Show error messages and get error count back
-          errorOutput = new LintErrorOutput(result, grunt)
+          errorOutput = new LintErrorOutput(result, options, grunt)
           fileLintIssues = errorOutput.display(options.imports)
 
           errorCount += fileLintIssues.errors

--- a/src/lib/lint-error-output.coffee
+++ b/src/lib/lint-error-output.coffee
@@ -7,7 +7,7 @@ chalk = require 'chalk'
 stripPath = require 'strip-path'
 
 class LintErrorOutput
-  constructor: (@result, @grunt) ->
+  constructor: (@result, @options, @grunt) ->
 
   display: (importsToLint) ->
     sourceMap = new SourceMapConsumer(@result.sourceMap)
@@ -64,7 +64,7 @@ class LintErrorOutput
     # Group the errors by message
     messageGroups = _.groupBy messages, ({message, rule, type}) ->
       fullMsg = "#{message}"
-      fullMsg = "(#{type}) #{fullMsg}" if type? and type.length isnt 0
+      fullMsg = "#{fullMsg}" if type? and type.length isnt 0
       fullMsg += " #{rule.desc}" if rule.desc and rule.desc isnt message
       fullMsg
 
@@ -115,7 +115,11 @@ class LintErrorOutput
         lessSource = fileLines[source][line-1].slice(column)
 
         # Output the source line
-        @grunt.log.error(chalk.gray("#{filePath} [Line #{line}, Column #{column+1}]:\t")+ " #{lessSource.trim()}")
+        output = chalk.gray("#{filePath} [Line #{line}, Column #{column+1}]:\t")+ " #{lessSource.trim()}"
+        if @options.failOnError && (message.type is 'error' || @options.failOnWarning)
+          @grunt.log.error(output)
+        else
+          @grunt.log.writeln("   " + output)
 
     issueCounts
 


### PR DESCRIPTION
The characters `>>` before a warning are **red** when they will fail the task and **white** when they won't. I've also removed the `(warning)` and `(error)` from the beginning of each rule description.

@jgable, @mmerriam: Do you think this is an improvement? I think so, and if you agree, I'll add a few unit tests for this.

## Examples

In all examples, the `ids` rule is configured to be an error and the `zero-units` a warning.

#### Having `failOnError: true` and `failOnWarning: true`

This is still the default configuration.
![image](https://cloud.githubusercontent.com/assets/325325/13702012/da576fb8-e78b-11e5-8dc4-27bbd219ed37.png)

#### Having `failOnError: true` and `failOnWarning: false`
![image](https://cloud.githubusercontent.com/assets/325325/13701917/4d4c4df0-e78b-11e5-9cae-db8fb134f451.png)

#### Having `failOnError: false`
![image](https://cloud.githubusercontent.com/assets/325325/13702022/f3164ede-e78b-11e5-9d97-38e6c66ed1d7.png)