### PR TITLE
Bump csslint version to 1.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "async": "^1.5.2",
     "cache-swap": "~0.2.3",
     "chalk": "^1.1.3",
-    "csslint": "~0.10.0",
+    "csslint": "^1.0.5",
     "less": "~2.7.1",
     "lodash": "^4.12.0",
     "source-map": "~0.5.6",

--- a/spec/fixtures/file.less
+++ b/spec/fixtures/file.less
@@ -1,12 +1,12 @@
 body {
-  padding: 0px;
+  img {
+    border-width: 0pt;
+  }
 
 
   margin: 0em;
 
-  img {
-    border-width: 0pt;
-  }
+  padding: 0px;
 
   #id {
     height: 21%;

--- a/spec/less-lint-task-spec.coffee
+++ b/spec/less-lint-task-spec.coffee
@@ -268,9 +268,9 @@ describe 'LESS Lint task', ->
         parseString reportXml, (error, parsedReport) -> report = parsedReport
         errors = report.csslint.file[0].issue
         expect(errors.length).toBe 4
-        expect(errors[0].$.line).toBe '1'
-        expect(errors[1].$.line).toBe '4'
-        expect(errors[2].$.line).toBe '7'
+        expect(errors[0].$.line).toBe '6'
+        expect(errors[1].$.line).toBe '8'
+        expect(errors[2].$.line).toBe '2'
 
         # A little hack for csslint not reporting proper column on ids in selectors
         reportedEitherBodyOrIdLine = errors[3].$.line == '10' || errors[3].$.line == '0'

--- a/spec/lint-utils-spec.coffee
+++ b/spec/lint-utils-spec.coffee
@@ -30,14 +30,14 @@ describe 'lint-utils', ->
 
       less = fs.readFileSync(path.join(__dirname, 'fixtures', 'file.less'), 'utf8').split('\n')
       expect(linter.getPropertyName(less[0])).toBe null
-      expect(linter.getPropertyName(less[1])).toBe 'padding'
-      expect(linter.getPropertyName(less[2])).toBe null
+      expect(linter.getPropertyName(less[1])).toBe null
+      expect(linter.getPropertyName(less[2])).toBe 'border-width'
       expect(linter.getPropertyName(less[3])).toBe null
-      expect(linter.getPropertyName(less[4])).toBe 'margin'
+      expect(linter.getPropertyName(less[4])).toBe null
       expect(linter.getPropertyName(less[5])).toBe null
-      expect(linter.getPropertyName(less[6])).toBe null
-      expect(linter.getPropertyName(less[7])).toBe 'border-width'
-      expect(linter.getPropertyName(less[8])).toBe null
+      expect(linter.getPropertyName(less[6])).toBe 'margin'
+      expect(linter.getPropertyName(less[7])).toBe null
+      expect(linter.getPropertyName(less[8])).toBe 'padding'
       expect(linter.getPropertyName(less[9])).toBe null
       expect(linter.getPropertyName(less[10])).toBe null
       expect(linter.getPropertyName(less[11])).toBe 'height'
@@ -48,8 +48,8 @@ describe 'lint-utils', ->
   describe '.findPropertyLineNumber()', ->
     it 'returns the line number of the next line with the given property name', ->
       less = fs.readFileSync(path.join(__dirname, 'fixtures', 'file.less'), 'utf8')
-      expect(linter.findPropertyLineNumber(less, 0, 'padding')).toBe 1
-      expect(linter.findPropertyLineNumber(less, 2, 'padding')).toBe -1
-      expect(linter.findPropertyLineNumber(less, 4, 'margin')).toBe 4
-      expect(linter.findPropertyLineNumber(less, null, 'border-width')).toBe 7
+      expect(linter.findPropertyLineNumber(less, 0, 'padding')).toBe 8
+      expect(linter.findPropertyLineNumber(less, 2, 'padding')).toBe 8
+      expect(linter.findPropertyLineNumber(less, 4, 'margin')).toBe 6
+      expect(linter.findPropertyLineNumber(less, null, 'border-width')).toBe 2
       expect(linter.findPropertyLineNumber(less, Infinity, 'border-width')).toBe -1


### PR DESCRIPTION
Current used csslint version is very old, and does not handle some new rules and does not handle ignore tag correctly.