### PR TITLE
Bumped cache-swap version to fix #102

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "license": "MIT",
   "dependencies": {
     "async": "^1.5.2",
-    "cache-swap": "~0.2.3",
+    "cache-swap": "~0.3.0",
     "chalk": "^1.1.3",
     "csslint": "^1.0.5",
     "less": "~2.7.1",


### PR DESCRIPTION
Moving to the latest version of the cache-swap dependency, 0.3.0,
removes the deprecation warning about os.tmpDir() in my environment
(npm 6.4.1/node v10.13.0), when invoking "grunt" or "grunt test".