### PR TITLE
Bumped cache-swap version to fix os.tmpDir removal

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "license": "MIT",
   "dependencies": {
     "async": "^1.5.2",
-    "cache-swap": "~0.2.3",
+    "cache-swap": "~0.3.0",
     "chalk": "^1.1.3",
     "csslint": "^1.0.5",
     "less": "~2.7.1",


### PR DESCRIPTION
`os.tmpDir` is now removed in Node.js v14+: https://nodejs.org/api/deprecations.html#deprecations_dep0022_os_tmpdir

Fix via @bmarcotte in https://github.com/bmarcotte/grunt-lesslint/commit/8ebbd733a58897da005d650a033146fa9d02574e